### PR TITLE
Fix cropped images in GUI

### DIFF
--- a/Detect_NP/detection_gui/detection_gui_app.py
+++ b/Detect_NP/detection_gui/detection_gui_app.py
@@ -35,7 +35,8 @@ class Detection_gui(ctk.CTk):
         ctk.set_default_color_theme('blue')
 
         # Inizialicing window
-        self.geometry('1300x800+50+50')
+        # Increase window size to fit all displayed images
+        self.geometry('1500x850+50+50')
         self.title('Labeling app')
 
         # Window icon
@@ -86,10 +87,25 @@ class Detection_gui(ctk.CTk):
         self.current_image = 0
         
         # Images set up
-        self.image_microscope = Interactive_image(self.frame_images, self.zeros, title = 'Microscope Image', font=('American typewriter', 24), width= 720, height= 720)
+        # Display images using their native size
+        self.image_microscope = Interactive_image(
+            self.frame_images,
+            self.zeros,
+            title='Microscope Image',
+            font=('American typewriter', 24),
+            width=512,
+            height=512
+        )
         self.image_microscope.pack()
 
-        self.image_prediction = Interactive_image(self.frame_prediction, self.zeros, title = 'Model prediction', font=('American typewriter', 24), width= 720, height= 720)
+        self.image_prediction = Interactive_image(
+            self.frame_prediction,
+            self.zeros,
+            title='Model prediction',
+            font=('American typewriter', 24),
+            width=512,
+            height=512
+        )
         self.image_prediction.pack()
 
         # Simplifying commonly used variables from other scripts


### PR DESCRIPTION
## Summary
- enlarge GUI window to fit both 512x512 images
- show microscope and prediction images using native size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840182c8af08330a2457cdcb2f3e382